### PR TITLE
Add team logos to standings

### DIFF
--- a/src/api/ergast.ts
+++ b/src/api/ergast.ts
@@ -15,6 +15,7 @@ export interface DriverStanding {
   id: number;
   name: string;
   team: string;
+  teamLogo?: string;
   points: number;
   wins: number;
   podiums: number;
@@ -51,6 +52,8 @@ const COUNTRY_CODE_MAP: Record<string, string> = {
   Austria: 'AT',
   France: 'FR',
   Britain: 'GB',
+  'United Kingdom': 'GB',
+  'Great Britain': 'GB',
   Hungary: 'HU',
   Belgium: 'BE',
   Netherlands: 'NL',
@@ -59,7 +62,9 @@ const COUNTRY_CODE_MAP: Record<string, string> = {
   Mexico: 'MX',
   Brazil: 'BR',
   'United States': 'US',
-  'United Arab Emirates': 'AE'
+  'United Arab Emirates': 'AE',
+  UAE: 'AE',
+  Azerbaijan: 'AZ'
 };
 
 const TEAM_COLOR_MAP: Record<string, string> = {
@@ -69,7 +74,55 @@ const TEAM_COLOR_MAP: Record<string, string> = {
   McLaren: '#EA580C',
   Mercedes: '#00D4AA',
   'Aston Martin': '#00594F',
-  Alpine: '#0066CC'
+  Alpine: '#0066CC',
+  Williams: '#0066B3',
+  'Williams Racing': '#0066B3',
+  Haas: '#B6BABD',
+  'Haas F1 Team': '#B6BABD',
+  'MoneyGram Haas F1 Team': '#B6BABD',
+  'RB F1 Team': '#6692FF',
+  'Visa Cash App RB': '#6692FF',
+  'Scuderia AlphaTauri': '#6692FF',
+  Sauber: '#52E252',
+  'Kick Sauber': '#52E252',
+  'Stake F1 Team Kick Sauber': '#52E252'
+};
+
+const TEAM_LOGO_MAP: Record<string, string> = {
+  'Red Bull Racing':
+    'https://upload.wikimedia.org/wikipedia/en/thumb/6/6f/Red_Bull_Racing_logo.svg/200px-Red_Bull_Racing_logo.svg.png',
+  Ferrari:
+    'https://upload.wikimedia.org/wikipedia/en/thumb/d/d4/Scuderia_Ferrari_Logo.svg/200px-Scuderia_Ferrari_Logo.svg.png',
+  McLaren:
+    'https://upload.wikimedia.org/wikipedia/en/thumb/5/57/McLaren_F1_Logo.svg/200px-McLaren_F1_Logo.svg.png',
+  Mercedes:
+    'https://upload.wikimedia.org/wikipedia/commons/thumb/3/33/Mercedes-Benz_in_Motorsport_logo.svg/200px-Mercedes-Benz_in_Motorsport_logo.svg.png',
+  'Aston Martin':
+    'https://upload.wikimedia.org/wikipedia/commons/thumb/f/f5/Aston_Martin_F1_logo.svg/200px-Aston_Martin_F1_logo.svg.png',
+  Alpine:
+    'https://upload.wikimedia.org/wikipedia/commons/thumb/9/9e/Alpine_F1_Team_logo.svg/200px-Alpine_F1_Team_logo.svg.png',
+  Williams:
+    'https://upload.wikimedia.org/wikipedia/en/thumb/3/30/Williams_Racing_logo_2020.svg/200px-Williams_Racing_logo_2020.svg.png',
+  'Williams Racing':
+    'https://upload.wikimedia.org/wikipedia/en/thumb/3/30/Williams_Racing_logo_2020.svg/200px-Williams_Racing_logo_2020.svg.png',
+  Haas:
+    'https://upload.wikimedia.org/wikipedia/en/thumb/e/e3/Haas_F1_Team_logo.svg/200px-Haas_F1_Team_logo.svg.png',
+  'Haas F1 Team':
+    'https://upload.wikimedia.org/wikipedia/en/thumb/e/e3/Haas_F1_Team_logo.svg/200px-Haas_F1_Team_logo.svg.png',
+  'MoneyGram Haas F1 Team':
+    'https://upload.wikimedia.org/wikipedia/en/thumb/e/e3/Haas_F1_Team_logo.svg/200px-Haas_F1_Team_logo.svg.png',
+  'RB F1 Team':
+    'https://upload.wikimedia.org/wikipedia/en/thumb/0/04/RB_F1_Team_logo.svg/200px-RB_F1_Team_logo.svg.png',
+  'Visa Cash App RB':
+    'https://upload.wikimedia.org/wikipedia/en/thumb/0/04/RB_F1_Team_logo.svg/200px-RB_F1_Team_logo.svg.png',
+  'Scuderia AlphaTauri':
+    'https://upload.wikimedia.org/wikipedia/en/thumb/0/04/RB_F1_Team_logo.svg/200px-RB_F1_Team_logo.svg.png',
+  Sauber:
+    'https://upload.wikimedia.org/wikipedia/en/thumb/2/22/Stake_F1_Team_Kick_Sauber_logo.svg/200px-Stake_F1_Team_Kick_Sauber_logo.svg.png',
+  'Kick Sauber':
+    'https://upload.wikimedia.org/wikipedia/en/thumb/2/22/Stake_F1_Team_Kick_Sauber_logo.svg/200px-Stake_F1_Team_Kick_Sauber_logo.svg.png',
+  'Stake F1 Team Kick Sauber':
+    'https://upload.wikimedia.org/wikipedia/en/thumb/2/22/Stake_F1_Team_Kick_Sauber_logo.svg/200px-Stake_F1_Team_Kick_Sauber_logo.svg.png'
 };
 
 interface ErgastRace {
@@ -141,6 +194,7 @@ export async function fetchDriverStandings(year: number): Promise<DriverStanding
       id: idx + 1,
       name: `${d.Driver.givenName} ${d.Driver.familyName}`,
       team: teamName,
+      teamLogo: TEAM_LOGO_MAP[teamName],
       points: Number(d.points),
       wins: Number(d.wins),
       podiums: Number(d.podiums ?? 0),
@@ -170,6 +224,7 @@ export async function fetchConstructorStandings(year: number): Promise<Construct
       position: Number(c.position),
       previousPosition: Number(c.position),
       color: TEAM_COLOR_MAP[name] || '#666',
+      logo: TEAM_LOGO_MAP[name],
       drivers: []
     };
   });

--- a/src/api/ergast.ts
+++ b/src/api/ergast.ts
@@ -70,11 +70,20 @@ const COUNTRY_CODE_MAP: Record<string, string> = {
 const TEAM_COLOR_MAP: Record<string, string> = {
   'Red Bull': '#1E40AF',
   'Red Bull Racing': '#1E40AF',
+  'Oracle Red Bull Racing': '#1E40AF',
+  'Red Bull Racing Honda RBPT': '#1E40AF',
   Ferrari: '#DC2626',
+  'Scuderia Ferrari': '#DC2626',
   McLaren: '#EA580C',
+  'McLaren F1 Team': '#EA580C',
   Mercedes: '#00D4AA',
+  'Mercedes AMG Petronas F1 Team': '#00D4AA',
   'Aston Martin': '#00594F',
+  'Aston Martin Aramco F1 Team': '#00594F',
+  'Aston Martin Cognizant F1 Team': '#00594F',
   Alpine: '#0066CC',
+  'Alpine F1 Team': '#0066CC',
+  'BWT Alpine F1 Team': '#0066CC',
   Williams: '#0066B3',
   'Williams Racing': '#0066B3',
   Haas: '#B6BABD',
@@ -83,23 +92,45 @@ const TEAM_COLOR_MAP: Record<string, string> = {
   'RB F1 Team': '#6692FF',
   'Visa Cash App RB': '#6692FF',
   'Scuderia AlphaTauri': '#6692FF',
+  'Racing Bulls': '#6692FF',
   Sauber: '#52E252',
   'Kick Sauber': '#52E252',
-  'Stake F1 Team Kick Sauber': '#52E252'
+  'Stake F1 Team Kick Sauber': '#52E252',
+  'Alfa Romeo': '#52E252'
 };
 
 const TEAM_LOGO_MAP: Record<string, string> = {
   'Red Bull Racing':
     'https://upload.wikimedia.org/wikipedia/en/thumb/6/6f/Red_Bull_Racing_logo.svg/200px-Red_Bull_Racing_logo.svg.png',
+  'Oracle Red Bull Racing':
+    'https://upload.wikimedia.org/wikipedia/en/thumb/6/6f/Red_Bull_Racing_logo.svg/200px-Red_Bull_Racing_logo.svg.png',
+  'Red Bull Racing Honda RBPT':
+    'https://upload.wikimedia.org/wikipedia/en/thumb/6/6f/Red_Bull_Racing_logo.svg/200px-Red_Bull_Racing_logo.svg.png',
+  'Red Bull':
+    'https://upload.wikimedia.org/wikipedia/en/thumb/6/6f/Red_Bull_Racing_logo.svg/200px-Red_Bull_Racing_logo.svg.png',
   Ferrari:
+    'https://upload.wikimedia.org/wikipedia/en/thumb/d/d4/Scuderia_Ferrari_Logo.svg/200px-Scuderia_Ferrari_Logo.svg.png',
+  'Scuderia Ferrari':
     'https://upload.wikimedia.org/wikipedia/en/thumb/d/d4/Scuderia_Ferrari_Logo.svg/200px-Scuderia_Ferrari_Logo.svg.png',
   McLaren:
     'https://upload.wikimedia.org/wikipedia/en/thumb/5/57/McLaren_F1_Logo.svg/200px-McLaren_F1_Logo.svg.png',
+  'McLaren F1 Team':
+    'https://upload.wikimedia.org/wikipedia/en/thumb/5/57/McLaren_F1_Logo.svg/200px-McLaren_F1_Logo.svg.png',
   Mercedes:
+    'https://upload.wikimedia.org/wikipedia/commons/thumb/3/33/Mercedes-Benz_in_Motorsport_logo.svg/200px-Mercedes-Benz_in_Motorsport_logo.svg.png',
+  'Mercedes AMG Petronas F1 Team':
     'https://upload.wikimedia.org/wikipedia/commons/thumb/3/33/Mercedes-Benz_in_Motorsport_logo.svg/200px-Mercedes-Benz_in_Motorsport_logo.svg.png',
   'Aston Martin':
     'https://upload.wikimedia.org/wikipedia/commons/thumb/f/f5/Aston_Martin_F1_logo.svg/200px-Aston_Martin_F1_logo.svg.png',
+  'Aston Martin Aramco F1 Team':
+    'https://upload.wikimedia.org/wikipedia/commons/thumb/f/f5/Aston_Martin_F1_logo.svg/200px-Aston_Martin_F1_logo.svg.png',
+  'Aston Martin Cognizant F1 Team':
+    'https://upload.wikimedia.org/wikipedia/commons/thumb/f/f5/Aston_Martin_F1_logo.svg/200px-Aston_Martin_F1_logo.svg.png',
   Alpine:
+    'https://upload.wikimedia.org/wikipedia/commons/thumb/9/9e/Alpine_F1_Team_logo.svg/200px-Alpine_F1_Team_logo.svg.png',
+  'Alpine F1 Team':
+    'https://upload.wikimedia.org/wikipedia/commons/thumb/9/9e/Alpine_F1_Team_logo.svg/200px-Alpine_F1_Team_logo.svg.png',
+  'BWT Alpine F1 Team':
     'https://upload.wikimedia.org/wikipedia/commons/thumb/9/9e/Alpine_F1_Team_logo.svg/200px-Alpine_F1_Team_logo.svg.png',
   Williams:
     'https://upload.wikimedia.org/wikipedia/en/thumb/3/30/Williams_Racing_logo_2020.svg/200px-Williams_Racing_logo_2020.svg.png',
@@ -115,6 +146,8 @@ const TEAM_LOGO_MAP: Record<string, string> = {
     'https://upload.wikimedia.org/wikipedia/en/thumb/0/04/RB_F1_Team_logo.svg/200px-RB_F1_Team_logo.svg.png',
   'Visa Cash App RB':
     'https://upload.wikimedia.org/wikipedia/en/thumb/0/04/RB_F1_Team_logo.svg/200px-RB_F1_Team_logo.svg.png',
+  'Racing Bulls':
+    'https://upload.wikimedia.org/wikipedia/en/thumb/0/04/RB_F1_Team_logo.svg/200px-RB_F1_Team_logo.svg.png',
   'Scuderia AlphaTauri':
     'https://upload.wikimedia.org/wikipedia/en/thumb/0/04/RB_F1_Team_logo.svg/200px-RB_F1_Team_logo.svg.png',
   Sauber:
@@ -122,6 +155,8 @@ const TEAM_LOGO_MAP: Record<string, string> = {
   'Kick Sauber':
     'https://upload.wikimedia.org/wikipedia/en/thumb/2/22/Stake_F1_Team_Kick_Sauber_logo.svg/200px-Stake_F1_Team_Kick_Sauber_logo.svg.png',
   'Stake F1 Team Kick Sauber':
+    'https://upload.wikimedia.org/wikipedia/en/thumb/2/22/Stake_F1_Team_Kick_Sauber_logo.svg/200px-Stake_F1_Team_Kick_Sauber_logo.svg.png',
+  'Alfa Romeo':
     'https://upload.wikimedia.org/wikipedia/en/thumb/2/22/Stake_F1_Team_Kick_Sauber_logo.svg/200px-Stake_F1_Team_Kick_Sauber_logo.svg.png'
 };
 

--- a/src/components/ConstructorsStandings.tsx
+++ b/src/components/ConstructorsStandings.tsx
@@ -88,12 +88,17 @@ const ConstructorsStandings: React.FC = () => {
                     <h4 className="text-sm font-semibold text-gray-300">Drivers</h4>
                     <div className="flex space-x-2">
                       {constructor.drivers.map((driver, driverIndex) => (
-                        <div key={driverIndex} className="flex items-center space-x-2 bg-gray-800/50 rounded-lg px-3 py-1">
-                          <div className="w-6 h-6 rounded-full overflow-hidden border border-gray-600 bg-gray-700 flex items-center justify-center">
-                            <div className="text-xs font-bold text-gray-300">
-                              {driver.name.split(' ').map(n => n[0]).join('')}
-                            </div>
-                          </div>
+                        <div
+                          key={driverIndex}
+                          className="flex items-center space-x-2 bg-gray-800/50 rounded-lg px-3 py-1"
+                        >
+                          {constructor.logo && (
+                            <img
+                              src={constructor.logo}
+                              alt={constructor.name}
+                              className="w-6 h-6 rounded-full border border-gray-600 object-contain"
+                            />
+                          )}
                           <span className="text-sm font-medium text-white">{driver.name}</span>
                         </div>
                       ))}

--- a/src/components/DriversStandings.tsx
+++ b/src/components/DriversStandings.tsx
@@ -99,9 +99,17 @@ const DriversStandings: React.FC = () => {
                     </div>
                     
                     <div className="w-16 h-16 rounded-lg overflow-hidden border-2 border-gray-600 bg-gray-800 flex items-center justify-center">
-                      <div className="text-2xl font-bold text-gray-400">
-                        {driver.name.split(' ').map(n => n[0]).join('')}
-                      </div>
+                      {driver.teamLogo ? (
+                        <img
+                          src={driver.teamLogo}
+                          alt={driver.team}
+                          className="w-full h-full object-contain"
+                        />
+                      ) : (
+                        <div className="text-2xl font-bold text-gray-400">
+                          {driver.name.split(' ').map((n) => n[0]).join('')}
+                        </div>
+                      )}
                     </div>
                   </div>
 


### PR DESCRIPTION
## Summary
- map known team logos in the Ergast API layer
- include logo URLs for driver and constructor standings
- display team logo for each driver in driver standings
- show constructor logo beside drivers in constructor standings
- fill in missing team logo/color mapping and extend flag map

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68611da316608325b9a89364c1d2596b