### PR TITLE
Add driver photos and background car animation

### DIFF
--- a/src/api/ergast.ts
+++ b/src/api/ergast.ts
@@ -16,6 +16,7 @@ export interface DriverStanding {
   name: string;
   team: string;
   teamLogo?: string;
+  photo?: string;
   points: number;
   wins: number;
   podiums: number;
@@ -160,6 +161,29 @@ const TEAM_LOGO_MAP: Record<string, string> = {
     'https://upload.wikimedia.org/wikipedia/en/thumb/2/22/Stake_F1_Team_Kick_Sauber_logo.svg/200px-Stake_F1_Team_Kick_Sauber_logo.svg.png'
 };
 
+const DRIVER_PHOTO_MAP: Record<string, string> = {
+  'Max Verstappen':
+    'https://images.pexels.com/photos/15914435/pexels-photo-15914435.jpeg?auto=compress&cs=tinysrgb&w=100&h=100&dpr=1',
+  'Charles Leclerc':
+    'https://images.pexels.com/photos/15914439/pexels-photo-15914439.jpeg?auto=compress&cs=tinysrgb&w=100&h=100&dpr=1',
+  'Lando Norris':
+    'https://images.pexels.com/photos/17081144/pexels-photo-17081144.jpeg?auto=compress&cs=tinysrgb&w=100&h=100&dpr=1',
+  'Carlos Sainz':
+    'https://images.pexels.com/photos/17081143/pexels-photo-17081143.jpeg?auto=compress&cs=tinysrgb&w=100&h=100&dpr=1',
+  'Oscar Piastri':
+    'https://images.pexels.com/photos/17081142/pexels-photo-17081142.jpeg?auto=compress&cs=tinysrgb&w=100&h=100&dpr=1',
+  'George Russell':
+    'https://images.pexels.com/photos/17081141/pexels-photo-17081141.jpeg?auto=compress&cs=tinysrgb&w=100&h=100&dpr=1',
+  'Lewis Hamilton':
+    'https://images.pexels.com/photos/17081140/pexels-photo-17081140.jpeg?auto=compress&cs=tinysrgb&w=100&h=100&dpr=1',
+  'Sergio Perez':
+    'https://images.pexels.com/photos/17081139/pexels-photo-17081139.jpeg?auto=compress&cs=tinysrgb&w=100&h=100&dpr=1',
+  'Fernando Alonso':
+    'https://images.pexels.com/photos/17081138/pexels-photo-17081138.jpeg?auto=compress&cs=tinysrgb&w=100&h=100&dpr=1',
+  'Lance Stroll':
+    'https://images.pexels.com/photos/17081137/pexels-photo-17081137.jpeg?auto=compress&cs=tinysrgb&w=100&h=100&dpr=1'
+};
+
 interface ErgastRace {
   raceName: string;
   date: string;
@@ -225,11 +249,13 @@ export async function fetchDriverStandings(year: number): Promise<DriverStanding
   const standings: ErgastDriverStanding[] = json?.MRData?.StandingsTable?.StandingsLists?.[0]?.DriverStandings || [];
   return standings.map((d, idx) => {
     const teamName = d.Constructors?.[0]?.name || '';
+    const fullName = `${d.Driver.givenName} ${d.Driver.familyName}`;
     return {
       id: idx + 1,
-      name: `${d.Driver.givenName} ${d.Driver.familyName}`,
+      name: fullName,
       team: teamName,
       teamLogo: TEAM_LOGO_MAP[teamName],
+      photo: DRIVER_PHOTO_MAP[fullName],
       points: Number(d.points),
       wins: Number(d.wins),
       podiums: Number(d.podiums ?? 0),

--- a/src/api/openf1.ts
+++ b/src/api/openf1.ts
@@ -1,5 +1,28 @@
 export const OPENF1_BASE_URL = 'https://api.openf1.org/v1';
 
+const DRIVER_PHOTO_MAP: Record<string, string> = {
+  'Max Verstappen':
+    'https://images.pexels.com/photos/15914435/pexels-photo-15914435.jpeg?auto=compress&cs=tinysrgb&w=100&h=100&dpr=1',
+  'Charles Leclerc':
+    'https://images.pexels.com/photos/15914439/pexels-photo-15914439.jpeg?auto=compress&cs=tinysrgb&w=100&h=100&dpr=1',
+  'Lando Norris':
+    'https://images.pexels.com/photos/17081144/pexels-photo-17081144.jpeg?auto=compress&cs=tinysrgb&w=100&h=100&dpr=1',
+  'Carlos Sainz':
+    'https://images.pexels.com/photos/17081143/pexels-photo-17081143.jpeg?auto=compress&cs=tinysrgb&w=100&h=100&dpr=1',
+  'Oscar Piastri':
+    'https://images.pexels.com/photos/17081142/pexels-photo-17081142.jpeg?auto=compress&cs=tinysrgb&w=100&h=100&dpr=1',
+  'George Russell':
+    'https://images.pexels.com/photos/17081141/pexels-photo-17081141.jpeg?auto=compress&cs=tinysrgb&w=100&h=100&dpr=1',
+  'Lewis Hamilton':
+    'https://images.pexels.com/photos/17081140/pexels-photo-17081140.jpeg?auto=compress&cs=tinysrgb&w=100&h=100&dpr=1',
+  'Sergio Perez':
+    'https://images.pexels.com/photos/17081139/pexels-photo-17081139.jpeg?auto=compress&cs=tinysrgb&w=100&h=100&dpr=1',
+  'Fernando Alonso':
+    'https://images.pexels.com/photos/17081138/pexels-photo-17081138.jpeg?auto=compress&cs=tinysrgb&w=100&h=100&dpr=1',
+  'Lance Stroll':
+    'https://images.pexels.com/photos/17081137/pexels-photo-17081137.jpeg?auto=compress&cs=tinysrgb&w=100&h=100&dpr=1'
+};
+
 export interface OpenF1Session {
   session_key?: number;
   event_name?: string;
@@ -48,6 +71,7 @@ export interface DriverStanding {
   id: number;
   name: string;
   team: string;
+  photo?: string;
   points: number;
   wins: number;
   podiums: number;
@@ -107,6 +131,7 @@ export async function fetchDriverStandings(
     id: idx + 1,
     name: d.driver_name,
     team: d.team_name,
+    photo: DRIVER_PHOTO_MAP[d.driver_name],
     points: Number(d.points),
     wins: Number(d.wins ?? 0),
     podiums: Number(d.podiums ?? 0),

--- a/src/components/DriversStandings.tsx
+++ b/src/components/DriversStandings.tsx
@@ -99,7 +99,13 @@ const DriversStandings: React.FC = () => {
                     </div>
                     
                     <div className="w-16 h-16 rounded-lg overflow-hidden border-2 border-gray-600 bg-gray-800 flex items-center justify-center">
-                      {driver.teamLogo ? (
+                      {driver.photo ? (
+                        <img
+                          src={driver.photo}
+                          alt={driver.name}
+                          className="w-full h-full object-cover"
+                        />
+                      ) : driver.teamLogo ? (
                         <img
                           src={driver.teamLogo}
                           alt={driver.team}

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -21,6 +21,11 @@ const Hero: React.FC = () => {
         <div className="absolute inset-0">
           <div className="absolute inset-0 bg-gradient-to-r from-red-500/20 via-transparent to-blue-500/20"></div>
           <div className="racing-lines"></div>
+          <img
+            src="https://images.pexels.com/photos/11676315/pexels-photo-11676315.jpeg?auto=compress&cs=tinysrgb&w=600"
+            alt="F1 car"
+            className="f1-car"
+          />
         </div>
         
         <div className="container mx-auto px-6 relative z-10">
@@ -62,6 +67,11 @@ const Hero: React.FC = () => {
       <div className="absolute inset-0">
         <div className="absolute inset-0 bg-gradient-to-r from-red-500/20 via-transparent to-blue-500/20"></div>
         <div className="racing-lines"></div>
+        <img
+          src="https://images.pexels.com/photos/11676315/pexels-photo-11676315.jpeg?auto=compress&cs=tinysrgb&w=600"
+          alt="F1 car"
+          className="f1-car"
+        />
       </div>
       
       <div className="container mx-auto px-6 relative z-10">

--- a/src/data/f1Data.ts
+++ b/src/data/f1Data.ts
@@ -1,8 +1,9 @@
 export const driversData = [
-  {
+  { 
     id: 1,
     name: 'Max Verstappen',
     team: 'Red Bull Racing',
+    photo: 'https://images.pexels.com/photos/15914435/pexels-photo-15914435.jpeg?auto=compress&cs=tinysrgb&w=100&h=100&dpr=1',
     teamColor: '#1E40AF',
     points: 63,
     wins: 2,
@@ -10,10 +11,11 @@ export const driversData = [
     position: 1,
     previousPosition: 1
   },
-  {
+  { 
     id: 2,
     name: 'Charles Leclerc',
     team: 'Ferrari',
+    photo: 'https://images.pexels.com/photos/15914439/pexels-photo-15914439.jpeg?auto=compress&cs=tinysrgb&w=100&h=100&dpr=1',
     teamColor: '#DC2626',
     points: 44,
     wins: 1,
@@ -21,10 +23,11 @@ export const driversData = [
     position: 2,
     previousPosition: 3
   },
-  {
+  { 
     id: 3,
     name: 'Lando Norris',
     team: 'McLaren',
+    photo: 'https://images.pexels.com/photos/17081144/pexels-photo-17081144.jpeg?auto=compress&cs=tinysrgb&w=100&h=100&dpr=1',
     teamColor: '#EA580C',
     points: 41,
     wins: 0,
@@ -32,10 +35,11 @@ export const driversData = [
     position: 3,
     previousPosition: 2
   },
-  {
+  { 
     id: 4,
     name: 'Carlos Sainz',
     team: 'Ferrari',
+    photo: 'https://images.pexels.com/photos/17081143/pexels-photo-17081143.jpeg?auto=compress&cs=tinysrgb&w=100&h=100&dpr=1',
     teamColor: '#DC2626',
     points: 32,
     wins: 0,
@@ -43,10 +47,11 @@ export const driversData = [
     position: 4,
     previousPosition: 4
   },
-  {
+  { 
     id: 5,
     name: 'Oscar Piastri',
     team: 'McLaren',
+    photo: 'https://images.pexels.com/photos/17081142/pexels-photo-17081142.jpeg?auto=compress&cs=tinysrgb&w=100&h=100&dpr=1',
     teamColor: '#EA580C',
     points: 28,
     wins: 0,
@@ -54,10 +59,11 @@ export const driversData = [
     position: 5,
     previousPosition: 6
   },
-  {
+  { 
     id: 6,
     name: 'George Russell',
     team: 'Mercedes',
+    photo: 'https://images.pexels.com/photos/17081141/pexels-photo-17081141.jpeg?auto=compress&cs=tinysrgb&w=100&h=100&dpr=1',
     teamColor: '#00D4AA',
     points: 22,
     wins: 0,
@@ -65,10 +71,11 @@ export const driversData = [
     position: 6,
     previousPosition: 5
   },
-  {
+  { 
     id: 7,
     name: 'Lewis Hamilton',
     team: 'Mercedes',
+    photo: 'https://images.pexels.com/photos/17081140/pexels-photo-17081140.jpeg?auto=compress&cs=tinysrgb&w=100&h=100&dpr=1',
     teamColor: '#00D4AA',
     points: 18,
     wins: 0,
@@ -76,10 +83,11 @@ export const driversData = [
     position: 7,
     previousPosition: 7
   },
-  {
+  { 
     id: 8,
     name: 'Sergio Perez',
     team: 'Red Bull Racing',
+    photo: 'https://images.pexels.com/photos/17081139/pexels-photo-17081139.jpeg?auto=compress&cs=tinysrgb&w=100&h=100&dpr=1',
     teamColor: '#1E40AF',
     points: 15,
     wins: 0,
@@ -87,10 +95,11 @@ export const driversData = [
     position: 8,
     previousPosition: 9
   },
-  {
+  { 
     id: 9,
     name: 'Fernando Alonso',
     team: 'Aston Martin',
+    photo: 'https://images.pexels.com/photos/17081138/pexels-photo-17081138.jpeg?auto=compress&cs=tinysrgb&w=100&h=100&dpr=1',
     teamColor: '#00594F',
     points: 12,
     wins: 0,
@@ -98,10 +107,11 @@ export const driversData = [
     position: 9,
     previousPosition: 8
   },
-  {
+  { 
     id: 10,
     name: 'Lance Stroll',
     team: 'Aston Martin',
+    photo: 'https://images.pexels.com/photos/17081137/pexels-photo-17081137.jpeg?auto=compress&cs=tinysrgb&w=100&h=100&dpr=1',
     teamColor: '#00594F',
     points: 8,
     wins: 0,

--- a/src/styles/animations.css
+++ b/src/styles/animations.css
@@ -64,6 +64,23 @@ h1, h2, h3, h4, h5, h6 {
   100% { transform: scale(1); opacity: 1; }
 }
 
+@keyframes car-drive {
+  0% {
+    transform: translateX(-30%);
+    opacity: 0;
+  }
+  10% {
+    opacity: 1;
+  }
+  90% {
+    opacity: 1;
+  }
+  100% {
+    transform: translateX(120%);
+    opacity: 0;
+  }
+}
+
 /* Custom Classes */
 .animate-gradient {
   background-size: 200% 200%;
@@ -143,6 +160,15 @@ h1, h2, h3, h4, h5, h6 {
 .hover-scale:hover {
   transform: scale(1.02);
   transition: transform 0.3s ease;
+}
+
+.f1-car {
+  position: absolute;
+  bottom: 10%;
+  left: -20%;
+  width: 250px;
+  opacity: 0.8;
+  animation: car-drive 8s linear infinite;
 }
 
 /* Gradient Backgrounds */


### PR DESCRIPTION
## Summary
- add driver photo map and expose `photo` field
- show driver photo in driver standings
- animate F1 car in hero background
- include fallback photos in sample data
- CSS for car animation

## Testing
- `npm run lint` *(fails: `npm: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_686383f07f788325b3a3dd8f61ddf193