### PR TITLE
Add artistic QR generator section with floral styling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "lucide-react": "^0.344.0",
+        "qr-code-styling": "^1.9.2",
         "react": "^18.3.1",
         "react-dom": "^18.3.1"
       },
@@ -3227,6 +3228,24 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/qr-code-styling": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/qr-code-styling/-/qr-code-styling-1.9.2.tgz",
+      "integrity": "sha512-RgJaZJ1/RrXJ6N0j7a+pdw3zMBmzZU4VN2dtAZf8ZggCfRB5stEQ3IoDNGaNhYY3nnZKYlYSLl5YkfWN5dPutg==",
+      "license": "MIT",
+      "dependencies": {
+        "qrcode-generator": "^1.4.4"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/qrcode-generator": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/qrcode-generator/-/qrcode-generator-1.5.2.tgz",
+      "integrity": "sha512-pItrW0Z9HnDBnFmgiNrY1uxRdri32Uh9EjNYLPVC2zZ3ZRIIEqBoDgm4DkvDwNNDHTK7FNkmr8zAa77BYc9xNw==",
+      "license": "MIT"
     },
     "node_modules/queue-microtask": {
       "version": "1.2.3",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "lucide-react": "^0.344.0",
+    "qr-code-styling": "^1.9.2",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"
   },

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,7 @@ import ConstructorsStandings from './components/ConstructorsStandings';
 import RaceSchedule from './components/RaceSchedule';
 import LiveTracker from './components/LiveTracker';
 import NewsFeed from './components/NewsFeed';
+import ArtisticQrGenerator from './components/ArtisticQrGenerator';
 import './styles/animations.css';
 
 function App() {
@@ -39,6 +40,12 @@ function App() {
         {activeSection === 'news' && (
           <div className="fade-in">
             <NewsFeed />
+          </div>
+        )}
+
+        {activeSection === 'qr' && (
+          <div className="fade-in">
+            <ArtisticQrGenerator />
           </div>
         )}
       </main>

--- a/src/components/ArtisticQrGenerator.tsx
+++ b/src/components/ArtisticQrGenerator.tsx
@@ -1,0 +1,213 @@
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import { Download, Flower2, RefreshCw, Sparkles } from 'lucide-react';
+import QRCodeStyling from 'qr-code-styling';
+import { drawFlowerField } from '../utils/qrArt';
+
+const QR_SIZE = 320;
+const palettePresets = [
+  ['#FEC6C2', '#FDA4AF', '#A5B4FC', '#C4B5FD', '#F9A8D4'],
+  ['#FDE68A', '#FCA5A5', '#FBCFE8', '#BAE6FD', '#C7D2FE'],
+  ['#BBF7D0', '#A7F3D0', '#99F6E4', '#E9D5FF', '#E0F2FE'],
+];
+
+const defaultData = 'https://www.formula1.com/';
+
+type QRCodeInstance = InstanceType<typeof QRCodeStyling>;
+
+const ArtisticQrGenerator: React.FC = () => {
+  const [data, setData] = useState(defaultData);
+  const [accentColor, setAccentColor] = useState('#0f766e');
+  const [selectedPalette, setSelectedPalette] = useState(0);
+  const [bloomDensity, setBloomDensity] = useState(20);
+  const qrContainerRef = useRef<HTMLDivElement | null>(null);
+  const overlayCanvasRef = useRef<HTMLCanvasElement | null>(null);
+  const qrCodeRef = useRef<QRCodeInstance | null>(null);
+
+  const palette = useMemo(() => {
+    const chosen = palettePresets[selectedPalette] ?? palettePresets[0];
+    return accentColor ? [...chosen.slice(0, chosen.length - 1), accentColor] : chosen;
+  }, [accentColor, selectedPalette]);
+
+  useEffect(() => {
+    if (!qrContainerRef.current || qrCodeRef.current) {
+      return;
+    }
+
+    const qrCode = new QRCodeStyling({
+      width: QR_SIZE,
+      height: QR_SIZE,
+      type: 'canvas',
+      data,
+      image: undefined,
+      dotsOptions: {
+        type: 'rounded',
+        color: '#0f172a',
+        gradient: {
+          type: 'linear',
+          rotation: 0.85,
+          colorStops: [
+            { offset: 0, color: '#0f172a' },
+            { offset: 1, color: accentColor },
+          ],
+        },
+      },
+      backgroundOptions: {
+        color: 'transparent',
+      },
+      cornersSquareOptions: {
+        type: 'extra-rounded',
+        color: accentColor,
+      },
+      cornersDotOptions: {
+        type: 'dot',
+        color: '#0f172a',
+      },
+    });
+
+    qrCode.append(qrContainerRef.current);
+    qrCodeRef.current = qrCode;
+  }, [accentColor, data]);
+
+  useEffect(() => {
+    if (!qrCodeRef.current) {
+      return;
+    }
+
+    qrCodeRef.current.update({
+      data,
+      dotsOptions: {
+        type: 'rounded',
+        gradient: {
+          type: 'linear',
+          rotation: 0.85,
+          colorStops: [
+            { offset: 0, color: '#0f172a' },
+            { offset: 1, color: accentColor },
+          ],
+        },
+      },
+      cornersSquareOptions: {
+        type: 'extra-rounded',
+        color: accentColor,
+      },
+    });
+  }, [data, accentColor]);
+
+  useEffect(() => {
+    const canvas = overlayCanvasRef.current;
+    if (!canvas) {
+      return;
+    }
+
+    drawFlowerField(canvas, {
+      width: QR_SIZE,
+      height: QR_SIZE,
+      bloomCount: bloomDensity,
+      palette,
+      accentColor,
+    });
+  }, [accentColor, bloomDensity, palette]);
+
+  const randomizePalette = () => {
+    setSelectedPalette((current) => (current + 1) % palettePresets.length);
+  };
+
+  const handleDownload = () => {
+    qrCodeRef.current?.download({ extension: 'png' });
+  };
+
+  return (
+    <section id="qr" className="relative py-24 px-6 bg-white/70">
+      <div className="max-w-6xl mx-auto grid gap-12 lg:grid-cols-2 items-center">
+        <div className="space-y-6">
+          <span className="inline-flex items-center space-x-2 rounded-full bg-[#008250]/10 px-3 py-1 text-sm font-medium text-[#008250]">
+            <Flower2 className="h-4 w-4" />
+            <span>Creative tools</span>
+          </span>
+          <h2 className="text-4xl font-bold text-gray-900 leading-tight">
+            Grow a <span className="text-[#008250]">field of flowers</span> around your QR code.
+          </h2>
+          <p className="text-lg text-gray-600 max-w-xl">
+            Share event passes, fan club links, or exclusive content with a lush botanical motif that keeps the QR code scannable while matching the vibrant Formula 1 identity.
+          </p>
+
+          <div className="space-y-4">
+            <label className="block text-sm font-semibold text-gray-700 uppercase tracking-wide">Target link or message</label>
+            <input
+              value={data}
+              onChange={(event) => setData(event.target.value)}
+              placeholder="https://"
+              className="w-full rounded-xl border border-gray-200 bg-white/90 px-4 py-3 text-base shadow-sm focus:border-[#008250] focus:outline-none focus:ring-2 focus:ring-[#008250]/40"
+            />
+          </div>
+
+          <div className="grid gap-6 sm:grid-cols-2">
+            <div className="space-y-2">
+              <label className="flex items-center justify-between text-sm font-semibold text-gray-700 uppercase tracking-wide">
+                Accent bloom color
+                <Sparkles className="h-4 w-4 text-[#008250]" />
+              </label>
+              <input
+                type="color"
+                value={accentColor}
+                onChange={(event) => setAccentColor(event.target.value)}
+                className="h-12 w-full cursor-pointer rounded-xl border border-gray-200 bg-white"
+              />
+            </div>
+            <div className="space-y-2">
+              <label className="flex items-center justify-between text-sm font-semibold text-gray-700 uppercase tracking-wide">
+                Bloom density
+                <RefreshCw className="h-4 w-4 text-[#008250]" />
+              </label>
+              <input
+                type="range"
+                min={8}
+                max={36}
+                value={bloomDensity}
+                onChange={(event) => setBloomDensity(Number(event.target.value))}
+                className="w-full accent-[#008250]"
+              />
+              <p className="text-xs text-gray-500">{bloomDensity} flowers</p>
+            </div>
+          </div>
+
+          <div className="flex flex-wrap items-center gap-3">
+            <button
+              type="button"
+              onClick={randomizePalette}
+              className="inline-flex items-center space-x-2 rounded-xl bg-[#008250]/10 px-4 py-2 text-sm font-semibold text-[#008250] transition hover:bg-[#008250]/20"
+            >
+              <RefreshCw className="h-4 w-4" />
+              <span>Cycle palette</span>
+            </button>
+            <button
+              type="button"
+              onClick={handleDownload}
+              className="inline-flex items-center space-x-2 rounded-xl bg-[#008250] px-4 py-2 text-sm font-semibold text-white shadow-lg shadow-[#008250]/30 transition hover:shadow-xl"
+            >
+              <Download className="h-4 w-4" />
+              <span>Download PNG</span>
+            </button>
+          </div>
+        </div>
+
+        <div className="relative flex items-center justify-center">
+          <div className="relative">
+            <div className="floral-shell absolute -inset-10" />
+            <div className="relative z-10 rounded-3xl border border-white/60 bg-white/50 p-6 shadow-2xl shadow-[#116dff]/10 backdrop-blur-xl">
+              <div className="relative aspect-square w-[320px] overflow-hidden rounded-2xl">
+                <canvas
+                  ref={overlayCanvasRef}
+                  className="absolute inset-0 h-full w-full floral-canvas pointer-events-none"
+                />
+                <div ref={qrContainerRef} className="relative z-10 h-full w-full" />
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+};
+
+export default ArtisticQrGenerator;

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Zap, Trophy, Calendar, Radio, Menu, X, Newspaper } from 'lucide-react';
+import { Zap, Trophy, Calendar, Radio, Menu, X, Newspaper, Flower2 } from 'lucide-react';
 
 interface HeaderProps {
   activeSection: string;
@@ -12,6 +12,7 @@ const Header: React.FC<HeaderProps> = ({ activeSection, setActiveSection }) => {
     { id: 'schedule', label: 'Race Calendar', icon: Calendar },
     { id: 'live', label: 'Live Tracker', icon: Radio },
     { id: 'news', label: 'News', icon: Newspaper },
+    { id: 'qr', label: 'Artistic QR', icon: Flower2 },
   ];
 
   const [menuOpen, setMenuOpen] = useState(false);

--- a/src/index.css
+++ b/src/index.css
@@ -1,3 +1,30 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+.floral-shell {
+  pointer-events: none;
+  background:
+    radial-gradient(circle at 20% 20%, rgba(17, 109, 255, 0.14), transparent 60%),
+    radial-gradient(circle at 80% 30%, rgba(0, 130, 80, 0.12), transparent 65%),
+    radial-gradient(circle at 50% 80%, rgba(253, 224, 71, 0.18), transparent 70%);
+  filter: blur(60px);
+  opacity: 0.85;
+  animation: floralPulse 12s ease-in-out infinite;
+}
+
+.floral-canvas {
+  mix-blend-mode: multiply;
+}
+
+@keyframes floralPulse {
+  0%,
+  100% {
+    transform: scale(1);
+    opacity: 0.8;
+  }
+  50% {
+    transform: scale(1.05);
+    opacity: 1;
+  }
+}

--- a/src/types/qr-code-styling.d.ts
+++ b/src/types/qr-code-styling.d.ts
@@ -1,0 +1,1 @@
+declare module 'qr-code-styling';

--- a/src/utils/qrArt.ts
+++ b/src/utils/qrArt.ts
@@ -8,7 +8,36 @@ export interface FlowerFieldOptions {
   gradientStops?: string[];
 }
 
+export interface PromptedArtOptions extends FlowerFieldOptions {
+  prompt?: string;
+  detailLevel?: number;
+}
+
+type MotifType = 'flowers' | 'ocean' | 'space' | 'desert' | 'forest' | 'tech';
+
 const defaultPalette = ['#FEC6C2', '#F9A8D4', '#C4B5FD', '#FDE68A', '#A5F3FC'];
+
+function setupCanvas(canvas: HTMLCanvasElement, width: number, height: number) {
+  const ctx = canvas.getContext('2d');
+  if (!ctx) {
+    return null;
+  }
+
+  const dpr = window.devicePixelRatio || 1;
+  canvas.width = width * dpr;
+  canvas.height = height * dpr;
+  canvas.style.width = `${width}px`;
+  canvas.style.height = `${height}px`;
+  if (typeof ctx.resetTransform === 'function') {
+    ctx.resetTransform();
+  } else {
+    ctx.setTransform(1, 0, 0, 1, 0, 0);
+  }
+  ctx.scale(dpr, dpr);
+  ctx.clearRect(0, 0, width, height);
+
+  return ctx;
+}
 
 function drawPetal(
   ctx: CanvasRenderingContext2D,
@@ -118,18 +147,10 @@ export function drawFlowerField(
     ]
   }: FlowerFieldOptions
 ) {
-  const ctx = canvas.getContext('2d');
+  const ctx = setupCanvas(canvas, width, height);
   if (!ctx) {
     return;
   }
-
-  const dpr = window.devicePixelRatio || 1;
-  canvas.width = width * dpr;
-  canvas.height = height * dpr;
-  canvas.style.width = `${width}px`;
-  canvas.style.height = `${height}px`;
-  ctx.resetTransform();
-  ctx.scale(dpr, dpr);
 
   const gradient = ctx.createLinearGradient(0, 0, width, height);
   gradientStops.forEach((stop, index) => {
@@ -166,4 +187,364 @@ export function drawFlowerField(
   }
 
   scatterDew(ctx, width, height);
+}
+
+function drawOceanDream(
+  canvas: HTMLCanvasElement,
+  {
+    width,
+    height,
+    palette = ['#0EA5E9', '#38BDF8', '#A5F3FC', '#0F172A'],
+    accentColor,
+    detailLevel = 22,
+  }: PromptedArtOptions
+) {
+  const ctx = setupCanvas(canvas, width, height);
+  if (!ctx) {
+    return;
+  }
+
+  const baseAccent = accentColor ?? '#0EA5E9';
+  const gradient = ctx.createLinearGradient(0, 0, 0, height);
+  gradient.addColorStop(0, palette[0] ?? '#0EA5E9');
+  gradient.addColorStop(0.5, palette[1] ?? '#38BDF8');
+  gradient.addColorStop(1, palette[2] ?? '#0F172A');
+  ctx.fillStyle = gradient;
+  ctx.fillRect(0, 0, width, height);
+
+  const waves = Math.max(3, Math.round(detailLevel / 6));
+  for (let i = 0; i < waves; i += 1) {
+    const amplitude = 6 + Math.random() * 12;
+    const yOffset = (height / waves) * i * 0.6 + height * 0.2;
+    ctx.beginPath();
+    ctx.moveTo(0, yOffset);
+    const segments = 6;
+    for (let s = 0; s <= segments; s += 1) {
+      const x = (width / segments) * s;
+      const y =
+        yOffset + Math.sin((s / segments) * Math.PI * 2 + i) * amplitude * (0.6 + Math.random() * 0.4);
+      ctx.lineTo(x, y);
+    }
+    ctx.lineTo(width, height);
+    ctx.lineTo(0, height);
+    ctx.closePath();
+    ctx.fillStyle = `rgba(14, 165, 233, ${0.12 + i * 0.08})`;
+    ctx.fill();
+  }
+
+  const bubbles = detailLevel + 10;
+  for (let i = 0; i < bubbles; i += 1) {
+    const x = Math.random() * width;
+    const y = height * 0.2 + Math.random() * (height * 0.7);
+    const radius = Math.random() * 4 + 1;
+    ctx.beginPath();
+    ctx.fillStyle = 'rgba(255,255,255,0.35)';
+    ctx.globalAlpha = 0.8;
+    ctx.arc(x, y, radius, 0, Math.PI * 2);
+    ctx.fill();
+  }
+
+  ctx.globalAlpha = 1;
+  ctx.strokeStyle = `${baseAccent}88`;
+  ctx.lineWidth = 2;
+  ctx.beginPath();
+  ctx.arc(width * 0.8, height * 0.25, 26, 0, Math.PI * 2);
+  ctx.stroke();
+}
+
+function drawSpaceNebula(
+  canvas: HTMLCanvasElement,
+  {
+    width,
+    height,
+    palette = ['#0F172A', '#1E3A8A', '#7C3AED', '#F472B6'],
+    accentColor,
+    detailLevel = 24,
+  }: PromptedArtOptions
+) {
+  const ctx = setupCanvas(canvas, width, height);
+  if (!ctx) {
+    return;
+  }
+
+  const gradient = ctx.createRadialGradient(width * 0.3, height * 0.4, 40, width * 0.5, height * 0.6, width);
+  gradient.addColorStop(0, palette[3] ?? '#F472B6');
+  gradient.addColorStop(0.4, palette[2] ?? '#7C3AED');
+  gradient.addColorStop(1, palette[0] ?? '#0F172A');
+  ctx.fillStyle = gradient;
+  ctx.fillRect(0, 0, width, height);
+
+  const nebulae = Math.max(3, Math.round(detailLevel / 8));
+  for (let i = 0; i < nebulae; i += 1) {
+    const x = Math.random() * width;
+    const y = Math.random() * height;
+    const radius = 60 + Math.random() * 90;
+    const radial = ctx.createRadialGradient(x, y, 0, x, y, radius);
+    const color = palette[(i + 1) % palette.length] ?? '#7C3AED';
+    radial.addColorStop(0, `${color}aa`);
+    radial.addColorStop(1, `${color}00`);
+    ctx.fillStyle = radial;
+    ctx.fillRect(x - radius, y - radius, radius * 2, radius * 2);
+  }
+
+  const stars = detailLevel * 4;
+  ctx.fillStyle = '#ffffff';
+  for (let i = 0; i < stars; i += 1) {
+    const x = Math.random() * width;
+    const y = Math.random() * height;
+    const radius = Math.random() * 1.5 + 0.5;
+    ctx.globalAlpha = Math.random() * 0.8 + 0.2;
+    ctx.beginPath();
+    ctx.arc(x, y, radius, 0, Math.PI * 2);
+    ctx.fill();
+  }
+
+  ctx.globalAlpha = 1;
+  if (accentColor) {
+    ctx.strokeStyle = `${accentColor}aa`;
+    ctx.lineWidth = 2;
+    ctx.beginPath();
+    ctx.arc(width * 0.75, height * 0.25, 18, 0, Math.PI * 2);
+    ctx.stroke();
+  }
+}
+
+function drawDesertSunset(
+  canvas: HTMLCanvasElement,
+  {
+    width,
+    height,
+    palette = ['#FDBA74', '#FB923C', '#F97316', '#FACC15'],
+    accentColor,
+    detailLevel = 16,
+  }: PromptedArtOptions
+) {
+  const ctx = setupCanvas(canvas, width, height);
+  if (!ctx) {
+    return;
+  }
+
+  const gradient = ctx.createLinearGradient(0, 0, 0, height);
+  gradient.addColorStop(0, palette[3] ?? '#FACC15');
+  gradient.addColorStop(0.5, palette[1] ?? '#FB923C');
+  gradient.addColorStop(1, palette[0] ?? '#FDBA74');
+  ctx.fillStyle = gradient;
+  ctx.fillRect(0, 0, width, height);
+
+  const dunes = Math.max(2, Math.round(detailLevel / 8));
+  for (let i = 0; i < dunes; i += 1) {
+    const yBase = height * (0.5 + i * 0.15);
+    ctx.beginPath();
+    ctx.moveTo(0, yBase);
+    const peak = yBase - 25 - Math.random() * 15;
+    ctx.quadraticCurveTo(width * 0.25, peak, width * 0.5, yBase - 10);
+    ctx.quadraticCurveTo(width * 0.75, yBase + 10, width, yBase - 5);
+    ctx.lineTo(width, height);
+    ctx.lineTo(0, height);
+    ctx.closePath();
+    ctx.fillStyle = `rgba(249, 115, 22, ${0.25 + i * 0.15})`;
+    ctx.fill();
+  }
+
+  ctx.fillStyle = accentColor ?? '#fde68a';
+  ctx.globalAlpha = 0.9;
+  ctx.beginPath();
+  ctx.arc(width * 0.2, height * 0.28, 28, 0, Math.PI * 2);
+  ctx.fill();
+  ctx.globalAlpha = 1;
+}
+
+function drawForestGlade(
+  canvas: HTMLCanvasElement,
+  {
+    width,
+    height,
+    palette = ['#DCFCE7', '#A7F3D0', '#4ADE80', '#166534'],
+    accentColor,
+    detailLevel = 20,
+  }: PromptedArtOptions
+) {
+  const ctx = setupCanvas(canvas, width, height);
+  if (!ctx) {
+    return;
+  }
+
+  const gradient = ctx.createLinearGradient(0, 0, 0, height);
+  gradient.addColorStop(0, palette[0] ?? '#DCFCE7');
+  gradient.addColorStop(0.5, palette[1] ?? '#A7F3D0');
+  gradient.addColorStop(1, palette[3] ?? '#166534');
+  ctx.fillStyle = gradient;
+  ctx.fillRect(0, 0, width, height);
+
+  const treeCount = Math.max(6, detailLevel);
+  for (let i = 0; i < treeCount; i += 1) {
+    const x = Math.random() * width;
+    const base = height * (0.6 + Math.random() * 0.3);
+    const heightFactor = height * 0.25 + Math.random() * height * 0.2;
+    ctx.fillStyle = 'rgba(22, 101, 52, 0.55)';
+    ctx.beginPath();
+    ctx.moveTo(x, base - heightFactor);
+    ctx.lineTo(x - 14, base);
+    ctx.lineTo(x + 14, base);
+    ctx.closePath();
+    ctx.fill();
+  }
+
+  const fireflies = Math.max(12, detailLevel * 1.2);
+  for (let i = 0; i < fireflies; i += 1) {
+    const x = Math.random() * width;
+    const y = Math.random() * height * 0.7;
+    const radius = Math.random() * 2 + 1;
+    ctx.beginPath();
+    ctx.fillStyle = `${accentColor ?? '#fef08a'}aa`;
+    ctx.globalAlpha = Math.random() * 0.6 + 0.3;
+    ctx.arc(x, y, radius, 0, Math.PI * 2);
+    ctx.fill();
+  }
+
+  ctx.globalAlpha = 1;
+}
+
+function drawNeonCircuit(
+  canvas: HTMLCanvasElement,
+  {
+    width,
+    height,
+    palette = ['#0F172A', '#0EA5E9', '#22D3EE', '#F472B6'],
+    accentColor,
+    detailLevel = 24,
+  }: PromptedArtOptions
+) {
+  const ctx = setupCanvas(canvas, width, height);
+  if (!ctx) {
+    return;
+  }
+
+  const gradient = ctx.createLinearGradient(0, 0, width, height);
+  gradient.addColorStop(0, palette[0] ?? '#0F172A');
+  gradient.addColorStop(1, palette[1] ?? '#0EA5E9');
+  ctx.fillStyle = gradient;
+  ctx.fillRect(0, 0, width, height);
+
+  ctx.strokeStyle = `${accentColor ?? '#22D3EE'}66`;
+  ctx.lineWidth = 1.5;
+  const gridSize = 24;
+  for (let x = 0; x < width; x += gridSize) {
+    ctx.beginPath();
+    ctx.moveTo(x, 0);
+    ctx.lineTo(x, height);
+    ctx.stroke();
+  }
+  for (let y = 0; y < height; y += gridSize) {
+    ctx.beginPath();
+    ctx.moveTo(0, y);
+    ctx.lineTo(width, y);
+    ctx.stroke();
+  }
+
+  const traces = Math.max(6, detailLevel);
+  for (let i = 0; i < traces; i += 1) {
+    let currentX = Math.random() * width;
+    let currentY = Math.random() * height;
+    ctx.beginPath();
+    ctx.moveTo(currentX, currentY);
+    for (let segment = 0; segment < 4; segment += 1) {
+      const direction = Math.random() > 0.5 ? 1 : -1;
+      const length = 16 + Math.random() * 40;
+      if (Math.random() > 0.5) {
+        currentX += direction * length;
+      } else {
+        currentY += direction * length;
+      }
+      ctx.lineTo(currentX, currentY);
+    }
+    ctx.strokeStyle = [palette[2] ?? '#22D3EE', palette[3] ?? '#F472B6'][i % 2];
+    ctx.stroke();
+  }
+
+  ctx.globalAlpha = 0.6;
+  ctx.fillStyle = `${accentColor ?? '#22D3EE'}55`;
+  ctx.beginPath();
+  ctx.arc(width * 0.85, height * 0.2, 18, 0, Math.PI * 2);
+  ctx.fill();
+  ctx.globalAlpha = 1;
+}
+
+function detectMotif(prompt?: string): MotifType {
+  if (!prompt) {
+    return 'flowers';
+  }
+
+  const normalized = prompt.toLowerCase();
+  if (/space|galaxy|star|cosmic|nebula/.test(normalized)) {
+    return 'space';
+  }
+  if (/ocean|sea|wave|coral|underwater/.test(normalized)) {
+    return 'ocean';
+  }
+  if (/desert|dune|sunset|canyon|sand/.test(normalized)) {
+    return 'desert';
+  }
+  if (/forest|jungle|grove|leaves|moss|woodland/.test(normalized)) {
+    return 'forest';
+  }
+  if (/tech|neon|cyber|futur|circuit|synth/.test(normalized)) {
+    return 'tech';
+  }
+  if (/flower|floral|garden|bloom|petal/.test(normalized)) {
+    return 'flowers';
+  }
+  return 'flowers';
+}
+
+function motifPalette(motif: MotifType, accentColor?: string): string[] {
+  switch (motif) {
+    case 'ocean':
+      return ['#0EA5E9', '#38BDF8', '#22D3EE', accentColor ?? '#14B8A6'];
+    case 'space':
+      return ['#0F172A', '#1E3A8A', '#4338CA', accentColor ?? '#F472B6'];
+    case 'desert':
+      return ['#FDBA74', '#FB923C', '#F97316', accentColor ?? '#FACC15'];
+    case 'forest':
+      return ['#DCFCE7', '#86EFAC', '#4ADE80', accentColor ?? '#166534'];
+    case 'tech':
+      return ['#0F172A', '#111827', accentColor ?? '#22D3EE', '#F472B6'];
+    case 'flowers':
+    default:
+      return ['#FEC6C2', '#F9A8D4', '#C4B5FD', accentColor ?? '#0F172A'];
+  }
+}
+
+export function drawPromptedArt(canvas: HTMLCanvasElement, options: PromptedArtOptions) {
+  const { prompt, accentColor, palette, bloomCount, detailLevel, ...rest } = options;
+  const motif = detectMotif(prompt);
+  const paletteForMotif = palette?.length ? palette : motifPalette(motif, accentColor);
+  const shared: PromptedArtOptions = {
+    accentColor,
+    palette: paletteForMotif,
+    bloomCount,
+    detailLevel,
+    ...rest,
+  };
+
+  switch (motif) {
+    case 'ocean':
+      drawOceanDream(canvas, shared);
+      break;
+    case 'space':
+      drawSpaceNebula(canvas, shared);
+      break;
+    case 'desert':
+      drawDesertSunset(canvas, shared);
+      break;
+    case 'forest':
+      drawForestGlade(canvas, shared);
+      break;
+    case 'tech':
+      drawNeonCircuit(canvas, shared);
+      break;
+    case 'flowers':
+    default:
+      drawFlowerField(canvas, shared);
+  }
 }

--- a/src/utils/qrArt.ts
+++ b/src/utils/qrArt.ts
@@ -1,0 +1,169 @@
+export interface FlowerFieldOptions {
+  width: number;
+  height: number;
+  bloomCount?: number;
+  palette?: string[];
+  accentColor?: string;
+  stemColor?: string;
+  gradientStops?: string[];
+}
+
+const defaultPalette = ['#FEC6C2', '#F9A8D4', '#C4B5FD', '#FDE68A', '#A5F3FC'];
+
+function drawPetal(
+  ctx: CanvasRenderingContext2D,
+  radius: number,
+  thickness: number,
+  angle: number,
+  color: string,
+  opacity = 0.85
+) {
+  ctx.save();
+  ctx.rotate(angle);
+  const gradient = ctx.createLinearGradient(0, -radius, 0, radius);
+  gradient.addColorStop(0, `${color}cc`);
+  gradient.addColorStop(0.5, `${color}e6`);
+  gradient.addColorStop(1, `${color}99`);
+  ctx.beginPath();
+  ctx.ellipse(0, 0, thickness, radius, 0, 0, Math.PI * 2);
+  ctx.fillStyle = gradient;
+  ctx.globalAlpha = opacity;
+  ctx.fill();
+  ctx.restore();
+}
+
+function drawBloom(
+  ctx: CanvasRenderingContext2D,
+  x: number,
+  y: number,
+  size: number,
+  palette: string[],
+  accentColor?: string
+) {
+  ctx.save();
+  ctx.translate(x, y);
+  ctx.shadowColor = 'rgba(17, 109, 255, 0.15)';
+  ctx.shadowBlur = size * 0.45;
+
+  const petals = Math.floor(5 + Math.random() * 3);
+  const baseColor = palette[Math.floor(Math.random() * palette.length)];
+  const petalThickness = size * (0.45 + Math.random() * 0.2);
+
+  for (let i = 0; i < petals; i += 1) {
+    const angle = (i / petals) * Math.PI * 2 + Math.random() * 0.2;
+    drawPetal(ctx, size, petalThickness, angle, baseColor, 0.8 + Math.random() * 0.1);
+  }
+
+  ctx.beginPath();
+  ctx.fillStyle = accentColor ?? '#0F172A';
+  ctx.globalAlpha = 0.9;
+  ctx.arc(0, 0, size * 0.25, 0, Math.PI * 2);
+  ctx.fill();
+
+  ctx.beginPath();
+  ctx.fillStyle = 'rgba(255,255,255,0.85)';
+  ctx.globalAlpha = 0.75;
+  ctx.arc(size * 0.1, -size * 0.1, size * 0.12, 0, Math.PI * 2);
+  ctx.fill();
+
+  ctx.restore();
+}
+
+function drawStem(
+  ctx: CanvasRenderingContext2D,
+  x: number,
+  y: number,
+  width: number,
+  height: number,
+  color: string
+) {
+  ctx.save();
+  ctx.beginPath();
+  ctx.strokeStyle = color;
+  ctx.lineWidth = width;
+  ctx.lineCap = 'round';
+  ctx.moveTo(x, y);
+  const controlX = x + (Math.random() - 0.5) * width * 15;
+  ctx.quadraticCurveTo(controlX, y + height * 0.5, x, y + height);
+  ctx.stroke();
+  ctx.restore();
+}
+
+function scatterDew(ctx: CanvasRenderingContext2D, width: number, height: number) {
+  const dewDrops = 30;
+  for (let i = 0; i < dewDrops; i += 1) {
+    const x = Math.random() * width;
+    const y = Math.random() * height;
+    const radius = Math.random() * 2 + 1;
+    ctx.beginPath();
+    ctx.fillStyle = 'rgba(255, 255, 255, 0.4)';
+    ctx.arc(x, y, radius, 0, Math.PI * 2);
+    ctx.fill();
+  }
+}
+
+export function drawFlowerField(
+  canvas: HTMLCanvasElement,
+  {
+    width,
+    height,
+    bloomCount = 18,
+    palette = defaultPalette,
+    accentColor,
+    stemColor = 'rgba(16, 185, 129, 0.6)',
+    gradientStops = [
+      'rgba(252, 231, 243, 0.95)',
+      'rgba(221, 242, 253, 0.7)',
+      'rgba(209, 250, 229, 0.65)'
+    ]
+  }: FlowerFieldOptions
+) {
+  const ctx = canvas.getContext('2d');
+  if (!ctx) {
+    return;
+  }
+
+  const dpr = window.devicePixelRatio || 1;
+  canvas.width = width * dpr;
+  canvas.height = height * dpr;
+  canvas.style.width = `${width}px`;
+  canvas.style.height = `${height}px`;
+  ctx.resetTransform();
+  ctx.scale(dpr, dpr);
+
+  const gradient = ctx.createLinearGradient(0, 0, width, height);
+  gradientStops.forEach((stop, index) => {
+    gradient.addColorStop(index / Math.max(gradientStops.length - 1, 1), stop);
+  });
+  ctx.fillStyle = gradient;
+  ctx.fillRect(0, 0, width, height);
+
+  const horizon = height * 0.75;
+  ctx.save();
+  ctx.fillStyle = 'rgba(16, 185, 129, 0.2)';
+  ctx.beginPath();
+  ctx.moveTo(0, horizon);
+  ctx.quadraticCurveTo(width * 0.25, horizon - 20, width * 0.5, horizon - 10);
+  ctx.quadraticCurveTo(width * 0.75, horizon, width, horizon - 15);
+  ctx.lineTo(width, height);
+  ctx.lineTo(0, height);
+  ctx.closePath();
+  ctx.fill();
+  ctx.restore();
+
+  for (let i = 0; i < bloomCount; i += 1) {
+    const x = Math.random() * width;
+    const y = horizon - Math.random() * (height * 0.35);
+    const stemHeight = height - y;
+    drawStem(ctx, x, y, 2 + Math.random() * 1.5, stemHeight, stemColor);
+  }
+
+  for (let i = 0; i < bloomCount; i += 1) {
+    const x = Math.random() * width;
+    const y = horizon - Math.random() * (height * 0.4);
+    const size = 10 + Math.random() * 16;
+    drawBloom(ctx, x, y, size, palette, accentColor);
+  }
+
+  scatterDew(ctx, width, height);
+}


### PR DESCRIPTION
## Summary
- add an ArtisticQrGenerator experience with customizable QR codes layered over a floral canvas
- extract reusable flower field drawing utilities and supporting styles to drive the motif
- surface the new QR generator in app navigation and include the qr-code-styling dependency

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_6900ad2d61a88325a08aa077c4f49bd9